### PR TITLE
Directory permissions

### DIFF
--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -149,7 +149,7 @@ cron { '/srv/www/wp-tests':
 cron { 'check perms on content dirs ':
   command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
   minute => '0',
-  hour = '2',
+  hour => '2',
 }
 
 if 'physical' == $::virtual {

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -146,12 +146,6 @@ cron { '/srv/www/wp-tests':
   hour    => '*',
 }
 
-cron { 'check perms on content dirs ':
-  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; do find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
-  minute => '0',
-  hour => '2',
-}
-
 if 'physical' == $::virtual {
   # Create a local config
   file { 'local-config.php':

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -147,7 +147,7 @@ cron { '/srv/www/wp-tests':
 }
 
 cron { 'check perms on content dirs ':
-  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
+  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; do find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
   minute => '0',
   hour => '2',
 }

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -97,8 +97,8 @@ file { '/srv/www/wp-content':
 
 file { $wp_content_dirs:
     ensure  => directory,
-    recurse => true,
-    mode    => 0664,
+    recurse => false,
+    mode    => 0775,
     owner   => 'www-data',
     group   => 'www-data',
 }
@@ -144,6 +144,12 @@ cron { '/srv/www/wp-tests':
   command => '/usr/bin/svn up /srv/www/wp-tests > /dev/null 2>&1',
   minute  => '0',
   hour    => '*',
+}
+
+cron { 'check perms on content dirs ':
+  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
+  minute => '0',
+  hour = '2',
 }
 
 if 'physical' == $::virtual {


### PR DESCRIPTION
revised directory permission enforcement. Takes too long on puppet when the $wp_content_dirs are too big. Removed recursive permissions check on these directories and added a nightly cronjob to enforce these permissions instead
